### PR TITLE
Sanitize image styles, inline icons, and trim per-image runtime cost

### DIFF
--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -14,11 +14,15 @@ export const CONSTANTS = {
     BORDER: '#6C6C6C',
     BACKGROUND: 'rgba(255, 255, 255, 1)',
   },
+  // Inlined Material Symbols Outlined alignment icons (20px) as base64 data URLs.
+  // Avoids runtime fetch from fonts.gstatic.com so the extension works under
+  // strict CSP (img-src 'self'), in offline/blocked networks, and without
+  // leaking the user's IP/Referer to a third-party CDN on every editor session.
   ICONS: {
-    LEFT: 'https://fonts.gstatic.com/s/i/short-term/release/materialsymbolsoutlined/format_align_left/default/20px.svg',
+    LEFT: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iMjAiPjxwYXRoIGQ9Ik0xNDQtMTQ0di03Mmg2NzJ2NzJIMTQ0Wm0wLTE1MHYtNzJoNDgwdjcySDE0NFptMC0xNTB2LTcyaDY3MnY3MkgxNDRabTAtMTUwdi03Mmg0ODB2NzJIMTQ0Wm0wLTE1MHYtNzJoNjcydjcySDE0NFoiLz48L3N2Zz4=',
     CENTER:
-      'https://fonts.gstatic.com/s/i/short-term/release/materialsymbolsoutlined/format_align_center/default/20px.svg',
+      'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iMjAiPjxwYXRoIGQ9Ik0xNDQtMTQ0di03Mmg2NzJ2NzJIMTQ0Wm0xNDQtMTUwdi03MmgzODR2NzJIMjg4Wk0xNDQtNDQ0di03Mmg2NzJ2NzJIMTQ0Wm0xNDQtMTUwdi03MmgzODR2NzJIMjg4Wk0xNDQtNzQ0di03Mmg2NzJ2NzJIMTQ0WiIvPjwvc3ZnPg==',
     RIGHT:
-      'https://fonts.gstatic.com/s/i/short-term/release/materialsymbolsoutlined/format_align_right/default/20px.svg',
+      'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgLTk2MCA5NjAgOTYwIiB3aWR0aD0iMjAiPjxwYXRoIGQ9Ik0xNDQtNzQ0di03Mmg2NzJ2NzJIMTQ0Wm0xOTIgMTUwdi03Mmg0ODB2NzJIMzM2Wk0xNDQtNDQ0di03Mmg2NzJ2NzJIMTQ0Wm0xOTIgMTUwdi03Mmg0ODB2NzJIMzM2Wk0xNDQtMTQ0di03Mmg2NzJ2NzJIMTQ0WiIvPjwvc3ZnPg==',
   },
 } as const;

--- a/lib/controllers/figure-node-view.ts
+++ b/lib/controllers/figure-node-view.ts
@@ -81,7 +81,7 @@ export class FigureNodeView extends ImageNodeView {
 
   // Updates the DOM when the node's attrs change.
   // Returns false if the node type has changed to trigger a full re-render
-  private update = (node: ProseMirrorNode): boolean => {
+  protected override update = (node: ProseMirrorNode): boolean => {
     if (node.type !== this.context.node.type) return false;
 
     this.context.node = node;

--- a/lib/controllers/figure-node-view.ts
+++ b/lib/controllers/figure-node-view.ts
@@ -2,6 +2,7 @@ import { NodeSelection } from '@tiptap/pm/state';
 import { NodeView } from '@tiptap/pm/view';
 import { Node as ProseMirrorNode, DOMSerializer } from '@tiptap/pm/model';
 import { AttributeParser } from '../utils/attribute-parser';
+import { sanitizeStyle } from '../utils/style-sanitizer';
 import { ImageNodeView } from './image-node-view';
 
 export class FigureNodeView extends ImageNodeView {
@@ -12,13 +13,15 @@ export class FigureNodeView extends ImageNodeView {
     if (typeof getPos === 'function') {
       this.clearContainerBorder();
 
+      const containerStyle = sanitizeStyle(this.elements.container.style.cssText);
+      const wrapperStyle = sanitizeStyle(this.elements.wrapper.style.cssText);
       const newAttrs = {
         ...this.context.node.attrs,
         width:
-          AttributeParser.extractWidthFromStyle(this.elements.container.style.cssText) ??
+          AttributeParser.extractWidthFromStyle(containerStyle) ??
           this.context.node.attrs.width,
-        containerStyle: `${this.elements.container.style.cssText}`,
-        wrapperStyle: `${this.elements.wrapper.style.cssText}`,
+        containerStyle,
+        wrapperStyle,
       };
 
       // setNodeMarkup causes the current NodeSelection to fall back to TextSelection inside the figcaption
@@ -82,8 +85,8 @@ export class FigureNodeView extends ImageNodeView {
     if (node.type !== this.context.node.type) return false;
 
     this.context.node = node;
-    this.elements.wrapper.setAttribute('style', node.attrs.wrapperStyle);
-    this.elements.container.setAttribute('style', node.attrs.containerStyle);
+    this.elements.wrapper.setAttribute('style', sanitizeStyle(node.attrs.wrapperStyle));
+    this.elements.container.setAttribute('style', sanitizeStyle(node.attrs.containerStyle));
     this.setupImageAttributes();
     this.elements.img.setAttribute('style', 'cursor: pointer');
     this.applyResizeLimits();

--- a/lib/controllers/image-node-view.ts
+++ b/lib/controllers/image-node-view.ts
@@ -1,3 +1,4 @@
+import { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { CONSTANTS } from '../constants';
 import { utils } from '../utils';
 import { AttributeParser } from '../utils/attribute-parser';
@@ -166,7 +167,39 @@ export class ImageNodeView {
     this.removeResizeElements();
   };
 
-  initialize(): { dom: HTMLElement; destroy?: () => void } {
+  /**
+   * Reuses the existing DOM when ProseMirror replaces the underlying node
+   * (e.g. on resize/alignment commits or external attr updates). Without
+   * this hook ProseMirror would destroy and recreate the NodeView on every
+   * setNodeMarkup, causing the <img> to reload, listeners to be re-bound,
+   * and any open resize UI to vanish mid-interaction.
+   */
+  protected update = (node: ProseMirrorNode): boolean => {
+    if (node.type !== this.context.node.type) return false;
+
+    const prev = this.context.node;
+    this.context.node = node;
+
+    if (prev.attrs.wrapperStyle !== node.attrs.wrapperStyle) {
+      this.elements.wrapper.setAttribute('style', sanitizeStyle(node.attrs.wrapperStyle));
+    }
+    if (prev.attrs.containerStyle !== node.attrs.containerStyle) {
+      this.elements.container.setAttribute('style', sanitizeStyle(node.attrs.containerStyle));
+    }
+
+    const imgAttrChanged =
+      prev.attrs.src !== node.attrs.src ||
+      prev.attrs.alt !== node.attrs.alt ||
+      prev.attrs.title !== node.attrs.title;
+    if (imgAttrChanged || prev.attrs.containerStyle !== node.attrs.containerStyle) {
+      this.setupImageAttributes();
+    }
+
+    this.applyResizeLimits();
+    return true;
+  };
+
+  initialize(): { dom: HTMLElement; update?: (node: ProseMirrorNode) => boolean; destroy?: () => void } {
     this.setupDOMStructure();
     this.setupImageAttributes();
     this.applyResizeLimits();
@@ -179,6 +212,7 @@ export class ImageNodeView {
 
     return {
       dom: this.elements.wrapper,
+      update: this.update,
       destroy: this.destroy,
     };
   }

--- a/lib/controllers/image-node-view.ts
+++ b/lib/controllers/image-node-view.ts
@@ -2,6 +2,7 @@ import { CONSTANTS } from '../constants';
 import { utils } from '../utils';
 import { AttributeParser } from '../utils/attribute-parser';
 import { clampWidth } from '../utils/clamp-width';
+import { sanitizeStyle } from '../utils/style-sanitizer';
 import { ImageElements, ResizeLimits } from '../types';
 import { PositionController } from './position-controller';
 import { ResizeController } from './resize-controller';
@@ -26,10 +27,14 @@ export class ImageNodeView {
     this.removeResizeElements();
     this.createPositionController();
 
-    this.elements.container.setAttribute(
-      'style',
-      `position: relative; border: 1px dashed ${CONSTANTS.COLORS.BORDER}; ${this.context.node.attrs.containerStyle}`
-    );
+    // Always re-apply the sanitized container style first so any rules left
+    // over from a previous interaction are cleared, then add the transient
+    // selection border via direct property assignment (not cssText) so it
+    // can never be persisted into the node attrs.
+    const sanitized = sanitizeStyle(this.context.node.attrs.containerStyle);
+    this.elements.container.setAttribute('style', sanitized);
+    this.elements.container.style.position = 'relative';
+    this.elements.container.style.border = `1px dashed ${CONSTANTS.COLORS.BORDER}`;
 
     this.applyResizeLimits();
     this.createResizeHandler();
@@ -69,13 +74,15 @@ export class ImageNodeView {
     const { view, getPos } = this.context;
     if (typeof getPos === 'function') {
       this.clearContainerBorder();
+      const containerStyle = sanitizeStyle(this.elements.container.style.cssText);
+      const wrapperStyle = sanitizeStyle(this.elements.wrapper.style.cssText);
       const newAttrs = {
         ...this.context.node.attrs,
         width:
-          AttributeParser.extractWidthFromStyle(this.elements.container.style.cssText) ??
+          AttributeParser.extractWidthFromStyle(containerStyle) ??
           this.context.node.attrs.width,
-        containerStyle: `${this.elements.container.style.cssText}`,
-        wrapperStyle: `${this.elements.wrapper.style.cssText}`,
+        containerStyle,
+        wrapperStyle,
       };
       view.dispatch(view.state.tr.setNodeMarkup(getPos(), null, newAttrs));
     }
@@ -92,10 +99,10 @@ export class ImageNodeView {
   protected setupDOMStructure(): void {
     const { wrapperStyle, containerStyle } = this.context.node.attrs;
 
-    this.elements.wrapper.setAttribute('style', wrapperStyle);
+    this.elements.wrapper.setAttribute('style', sanitizeStyle(wrapperStyle));
     this.elements.wrapper.appendChild(this.elements.container);
 
-    this.elements.container.setAttribute('style', containerStyle);
+    this.elements.container.setAttribute('style', sanitizeStyle(containerStyle));
     this.elements.container.appendChild(this.elements.img);
   }
 

--- a/lib/controllers/image-node-view.ts
+++ b/lib/controllers/image-node-view.ts
@@ -4,6 +4,7 @@ import { utils } from '../utils';
 import { AttributeParser } from '../utils/attribute-parser';
 import { clampWidth } from '../utils/clamp-width';
 import { sanitizeStyle } from '../utils/style-sanitizer';
+import { subscribeDocumentClick } from '../utils/document-click-manager';
 import { ImageElements, ResizeLimits } from '../types';
 import { PositionController } from './position-controller';
 import { ResizeController } from './resize-controller';
@@ -20,6 +21,7 @@ export class ImageNodeView {
   protected elements: ImageElements;
   private inline: boolean;
   private resizeLimits: ResizeLimits;
+  private unsubscribeDocumentClick: (() => void) | null = null;
   private handleContainerClick = (): void => {
     const isMobile = utils.isMobile();
     const editorDom = this.context.view.dom as HTMLElement | undefined;
@@ -158,12 +160,13 @@ export class ImageNodeView {
   }
 
   protected setupContentClick(): void {
-    document.addEventListener('click', this.handleDocumentClick);
+    this.unsubscribeDocumentClick = subscribeDocumentClick(this.handleDocumentClick);
   }
 
   protected destroy = (): void => {
     this.elements.container.removeEventListener('click', this.handleContainerClick);
-    document.removeEventListener('click', this.handleDocumentClick);
+    this.unsubscribeDocumentClick?.();
+    this.unsubscribeDocumentClick = null;
     this.removeResizeElements();
   };
 

--- a/lib/controllers/position-controller.ts
+++ b/lib/controllers/position-controller.ts
@@ -32,40 +32,39 @@ export class PositionController {
     return controller;
   }
 
+  // Setting individual style properties via the CSSStyleDeclaration API lets
+  // the browser validate each value, and avoids the unbounded cssText growth
+  // (and CSS injection surface) that arose from concatenating style strings.
   private handleLeftClick(): void {
     if (!this.inline) {
-      this.elements.container.setAttribute(
-        'style',
-        `${this.elements.container.style.cssText} margin: 0 auto 0 0;`
-      );
+      this.elements.container.style.margin = '0 auto 0 0';
     } else {
-      const style = 'display: inline-block; float: left; padding-right: 8px;';
-      this.elements.wrapper.setAttribute('style', style);
-      this.elements.container.setAttribute('style', style);
+      this.applyInlineFloat('left');
     }
     this.dispatchNodeView();
   }
 
   private handleCenterClick(): void {
-    this.elements.container.setAttribute(
-      'style',
-      `${this.elements.container.style.cssText} margin: 0 auto;`
-    );
+    this.elements.container.style.margin = '0 auto';
     this.dispatchNodeView();
   }
 
   private handleRightClick(): void {
     if (!this.inline) {
-      this.elements.container.setAttribute(
-        'style',
-        `${this.elements.container.style.cssText} margin: 0 0 0 auto;`
-      );
+      this.elements.container.style.margin = '0 0 0 auto';
     } else {
-      const style = 'display: inline-block; float: right; padding-left: 8px;';
-      this.elements.wrapper.setAttribute('style', style);
-      this.elements.container.setAttribute('style', style);
+      this.applyInlineFloat('right');
     }
     this.dispatchNodeView();
+  }
+
+  private applyInlineFloat(side: 'left' | 'right'): void {
+    for (const el of [this.elements.wrapper, this.elements.container]) {
+      el.style.display = 'inline-block';
+      el.style.float = side;
+      el.style.paddingLeft = side === 'right' ? '8px' : '';
+      el.style.paddingRight = side === 'left' ? '8px' : '';
+    }
   }
 
   createPositionControls(): PositionController {

--- a/lib/controllers/resize-controller.ts
+++ b/lib/controllers/resize-controller.ts
@@ -11,6 +11,12 @@ export class ResizeController {
     startX: 0,
     startWidth: 0,
   };
+  // High-frequency pointer events (especially 1000Hz mice) can fire many
+  // times per frame. Coalesce updates through requestAnimationFrame so the
+  // browser only paints once per frame and we avoid forcing layout in the
+  // input handler.
+  private pendingWidth: number | null = null;
+  private rafId: number | null = null;
 
   constructor(
     elements: ImageElements,
@@ -22,6 +28,30 @@ export class ResizeController {
     this.resizeLimits = resizeLimits;
   }
 
+  private scheduleWidthUpdate(width: number): void {
+    this.pendingWidth = width;
+    if (this.rafId !== null) return;
+    this.rafId = requestAnimationFrame(() => {
+      this.rafId = null;
+      this.flushWidth();
+    });
+  }
+
+  private flushWidth(): void {
+    if (this.pendingWidth === null) return;
+    const width = this.pendingWidth;
+    this.pendingWidth = null;
+    this.elements.container.style.width = `${width}px`;
+    this.elements.img.style.width = `${width}px`;
+  }
+
+  private cancelScheduledWidth(): void {
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+  }
+
   private handleMouseMove = (e: MouseEvent, index: number): void => {
     if (!this.state.isResizing) return;
 
@@ -29,14 +59,18 @@ export class ResizeController {
       index % 2 === 0 ? -(e.clientX - this.state.startX) : e.clientX - this.state.startX;
     const newWidth = clampWidth(this.state.startWidth + deltaX, this.resizeLimits);
 
-    this.elements.container.style.width = newWidth + 'px';
-    this.elements.img.style.width = newWidth + 'px';
+    this.scheduleWidthUpdate(newWidth);
   };
 
   private handleMouseUp = (): void => {
     if (this.state.isResizing) {
       this.state.isResizing = false;
     }
+    // Make sure the final pending width is applied even if no frame ticked
+    // between the last move and release; otherwise the persisted value would
+    // miss the user's last drag delta.
+    this.cancelScheduledWidth();
+    this.flushWidth();
     this.dispatchNodeView();
   };
 
@@ -49,14 +83,15 @@ export class ResizeController {
         : e.touches[0].clientX - this.state.startX;
     const newWidth = clampWidth(this.state.startWidth + deltaX, this.resizeLimits);
 
-    this.elements.container.style.width = newWidth + 'px';
-    this.elements.img.style.width = newWidth + 'px';
+    this.scheduleWidthUpdate(newWidth);
   };
 
   private handleTouchEnd = (): void => {
     if (this.state.isResizing) {
       this.state.isResizing = false;
     }
+    this.cancelScheduledWidth();
+    this.flushWidth();
     this.dispatchNodeView();
   };
 

--- a/lib/figure.ts
+++ b/lib/figure.ts
@@ -2,6 +2,7 @@ import { mergeAttributes } from '@tiptap/core';
 import { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { ImageResizeOptions, ImageResize } from './image-resize';
 import { StyleManager } from './utils/style-manager';
+import { sanitizeStyle } from './utils/style-sanitizer';
 import { ResizeLimits } from './types';
 import { FigureNodeView } from './controllers/figure-node-view';
 
@@ -53,16 +54,20 @@ export const Figure = ImageResize.extend<FigureOptions>({
         parseHTML: (element) => {
           const img = element.querySelector('img');
           const containerStyle = img?.getAttribute('containerstyle');
-          if (containerStyle) return containerStyle;
+          if (containerStyle) return sanitizeStyle(containerStyle);
 
           const width = img?.getAttribute('width');
           return width
             ? StyleManager.getContainerStyle(false, `${width}px`)
-            : `${img?.style.cssText}`;
+            : sanitizeStyle(img?.style.cssText);
         },
       },
       wrapperStyle: {
         default: StyleManager.getWrapperStyle(false),
+        parseHTML: (element) => {
+          const wrapperStyle = element.getAttribute('wrapperstyle');
+          return wrapperStyle ? sanitizeStyle(wrapperStyle) : StyleManager.getWrapperStyle(false);
+        },
       },
     };
   },

--- a/lib/figure.ts
+++ b/lib/figure.ts
@@ -1,10 +1,38 @@
 import { mergeAttributes } from '@tiptap/core';
 import { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { EditorState, NodeSelection } from '@tiptap/pm/state';
 import { ImageResizeOptions, ImageResize } from './image-resize';
 import { StyleManager } from './utils/style-manager';
 import { sanitizeStyle } from './utils/style-sanitizer';
 import { ResizeLimits } from './types';
 import { FigureNodeView } from './controllers/figure-node-view';
+
+/**
+ * Locates the figure node enclosing the current selection in O(depth) by
+ * walking up the resolved selection's parent chain. Also handles the case
+ * where the figure itself is the active NodeSelection. Replaces the prior
+ * full-document `nodesBetween` scan, which was O(N) and ran on every
+ * removeCaption / toggleCaption call.
+ */
+function findEnclosingFigure(
+  state: EditorState
+): { node: ProseMirrorNode; pos: number } | null {
+  const { selection } = state;
+
+  if (selection instanceof NodeSelection && selection.node.type.name === 'figure') {
+    return { node: selection.node, pos: selection.from };
+  }
+
+  const $pos = selection.$from;
+  for (let depth = $pos.depth; depth > 0; depth--) {
+    const node = $pos.node(depth);
+    if (node.type.name === 'figure') {
+      return { node, pos: $pos.before(depth) };
+    }
+  }
+
+  return null;
+}
 
 // Figure with caption is a block-level element, so inline option is intentionally omitted
 export interface FigureOptions extends Omit<ImageResizeOptions, 'inline'> {}
@@ -149,26 +177,12 @@ export const Figure = ImageResize.extend<FigureOptions>({
       removeCaption:
         () =>
         ({ state, dispatch }) => {
-          const { selection, schema } = state;
-          const { from } = selection;
-
-          let figurePos: number | undefined;
-          let figureNode: ProseMirrorNode | undefined;
-
-          state.doc.nodesBetween(0, state.doc.content.size, (node, pos) => {
-            if (node.type.name === 'figure') {
-              if (from >= pos && from <= pos + node.nodeSize) {
-                figurePos = pos;
-                figureNode = node;
-              }
-            }
-          });
-
-          if (figurePos === undefined || figureNode === undefined) return false;
+          const found = findEnclosingFigure(state);
+          if (!found) return false;
 
           if (dispatch) {
-            const imageNode = schema.nodes.imageResize.create(figureNode.attrs);
-            dispatch(state.tr.replaceWith(figurePos, figurePos + figureNode.nodeSize, imageNode));
+            const imageNode = state.schema.nodes.imageResize.create(found.node.attrs);
+            dispatch(state.tr.replaceWith(found.pos, found.pos + found.node.nodeSize, imageNode));
           }
 
           return true;
@@ -188,14 +202,7 @@ export const Figure = ImageResize.extend<FigureOptions>({
             return commands.addCaption(caption);
           }
 
-          let isFigure = false;
-          state.doc.nodesBetween(0, state.doc.content.size, (node, pos) => {
-            if (node.type.name === 'figure') {
-              if (from >= pos && from <= pos + node.nodeSize) isFigure = true;
-            }
-          });
-
-          return isFigure ? commands.removeCaption() : false;
+          return findEnclosingFigure(state) ? commands.removeCaption() : false;
         },
     };
   },

--- a/lib/image-resize.ts
+++ b/lib/image-resize.ts
@@ -1,5 +1,6 @@
 import Image, { ImageOptions } from '@tiptap/extension-image';
 import { StyleManager } from './utils/style-manager';
+import { sanitizeStyle } from './utils/style-sanitizer';
 import { ImageNodeView } from './controllers/image-node-view';
 import { ResizeLimits } from './types';
 
@@ -30,17 +31,21 @@ export const ImageResize = Image.extend<ImageResizeOptions>({
         parseHTML: (element) => {
           const containerStyle = element.getAttribute('containerstyle');
           if (containerStyle) {
-            return containerStyle;
+            return sanitizeStyle(containerStyle);
           }
 
           const width = element.getAttribute('width');
           return width
             ? StyleManager.getContainerStyle(inline, `${width}px`)
-            : `${element.style.cssText}`;
+            : sanitizeStyle(element.style.cssText);
         },
       },
       wrapperStyle: {
         default: StyleManager.getWrapperStyle(inline),
+        parseHTML: (element) => {
+          const wrapperStyle = element.getAttribute('wrapperstyle');
+          return wrapperStyle ? sanitizeStyle(wrapperStyle) : StyleManager.getWrapperStyle(inline);
+        },
       },
     };
   },

--- a/lib/utils/document-click-manager.ts
+++ b/lib/utils/document-click-manager.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared `document` click dispatcher.
+ *
+ * Every editable ImageNodeView used to attach its own `click` listener to
+ * `document` so it could detect clicks outside the image and dismiss the
+ * resize UI. With many images on a page this scaled to N listeners and made
+ * every click in the document fan out to N handlers.
+ *
+ * This module keeps a single `document` listener regardless of how many
+ * NodeViews subscribe. Subscribers are dispatched in insertion order; one
+ * subscriber throwing does not stop the rest.
+ */
+
+type ClickListener = (event: MouseEvent) => void;
+
+const subscribers: Set<ClickListener> = new Set();
+let attached = false;
+let attachedDoc: Document | null = null;
+
+const dispatch = (event: MouseEvent): void => {
+  // Snapshot to allow a subscriber to unsubscribe itself during dispatch
+  // without skipping siblings.
+  const snapshot = Array.from(subscribers);
+  for (const listener of snapshot) {
+    try {
+      listener(event);
+    } catch {
+      // Swallow per-subscriber errors so a buggy NodeView cannot block the
+      // rest of the page from receiving outside-click handling.
+    }
+  }
+};
+
+const ensureAttached = (): void => {
+  if (attached) return;
+  if (typeof document === 'undefined') return;
+  attachedDoc = document;
+  attachedDoc.addEventListener('click', dispatch);
+  attached = true;
+};
+
+const detachIfEmpty = (): void => {
+  if (!attached) return;
+  if (subscribers.size > 0) return;
+  attachedDoc?.removeEventListener('click', dispatch);
+  attached = false;
+  attachedDoc = null;
+};
+
+/**
+ * Registers a callback that will be invoked for every `click` event on
+ * `document`. Returns an idempotent `unsubscribe` function that the caller
+ * MUST invoke (typically from a NodeView `destroy` hook) to avoid leaks.
+ */
+export function subscribeDocumentClick(listener: ClickListener): () => void {
+  subscribers.add(listener);
+  ensureAttached();
+
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    subscribers.delete(listener);
+    detachIfEmpty();
+  };
+}
+
+/**
+ * Test-only helper. Clears all subscribers and detaches the underlying
+ * `document` listener so that test cases do not leak state into one
+ * another. Production code MUST NOT call this.
+ */
+export function __resetDocumentClickManagerForTests(): void {
+  subscribers.clear();
+  detachIfEmpty();
+}

--- a/lib/utils/style-sanitizer.ts
+++ b/lib/utils/style-sanitizer.ts
@@ -1,0 +1,108 @@
+/**
+ * Whitelist-based CSS style sanitizer.
+ *
+ * The image node persists its layout state in the `containerStyle` and
+ * `wrapperStyle` attributes as raw CSS text. Without sanitization a crafted
+ * document could embed arbitrary CSS (e.g. `position: fixed; top: 0; ...`,
+ * `background: url(...)`, expressions, etc.) that would survive load and be
+ * re-applied on every render, enabling UI redress, data exfiltration through
+ * CSS, and tracking via remote URLs.
+ *
+ * This sanitizer accepts only the small set of properties the extension
+ * actually uses for sizing/positioning and validates each value against
+ * conservative patterns. Unknown properties, function calls (url(),
+ * expression(), calc(), var(), attr(), ...), and unsafe characters are
+ * stripped silently.
+ */
+
+const DIMENSION_TOKEN = /^-?\d+(?:\.\d+)?(?:px|em|rem|%|vw|vh)$|^auto$|^0$/i;
+
+const isDimensionValue = (value: string): boolean => {
+  // Accept single tokens or shorthand sequences like "0 auto" / "10px 0 0 5px"
+  return value
+    .trim()
+    .split(/\s+/)
+    .every((token) => DIMENSION_TOKEN.test(token));
+};
+
+const isOneOf = (allowed: readonly string[]) => (value: string) =>
+  allowed.includes(value.trim().toLowerCase());
+
+type Validator = (value: string) => boolean;
+
+const ALLOWED_PROPERTIES: Record<string, Validator> = {
+  width: isDimensionValue,
+  height: isDimensionValue,
+  'min-width': isDimensionValue,
+  'max-width': isDimensionValue,
+  'min-height': isDimensionValue,
+  'max-height': isDimensionValue,
+
+  display: isOneOf(['block', 'inline-block', 'inline', 'flex', 'none', 'contents']),
+  float: isOneOf(['left', 'right', 'none']),
+  'text-align': isOneOf(['left', 'center', 'right', 'justify']),
+
+  margin: isDimensionValue,
+  'margin-top': isDimensionValue,
+  'margin-right': isDimensionValue,
+  'margin-bottom': isDimensionValue,
+  'margin-left': isDimensionValue,
+
+  padding: isDimensionValue,
+  'padding-top': isDimensionValue,
+  'padding-right': isDimensionValue,
+  'padding-bottom': isDimensionValue,
+  'padding-left': isDimensionValue,
+
+  cursor: isOneOf([
+    'pointer',
+    'default',
+    'auto',
+    'move',
+    'text',
+    'nwse-resize',
+    'nesw-resize',
+    'ew-resize',
+    'ns-resize',
+  ]),
+};
+
+// Reject any value containing characters that enable CSS escapes, function
+// calls, or rule injection. This is checked before per-property validation
+// as a coarse first pass.
+const UNSAFE_VALUE = /[<>{}\\\(\)`@]|\/\*|\*\//;
+
+/**
+ * Returns a sanitized CSS declaration string containing only whitelisted
+ * properties and validated values. Order is preserved; the output is
+ * normalized as `prop: value;` declarations separated by single spaces.
+ */
+export function sanitizeStyle(input: string | null | undefined): string {
+  if (!input) return '';
+
+  const declarations: string[] = [];
+  const seen = new Set<string>();
+
+  for (const rawDecl of input.split(';')) {
+    const colon = rawDecl.indexOf(':');
+    if (colon === -1) continue;
+
+    const property = rawDecl.slice(0, colon).trim().toLowerCase();
+    const value = rawDecl.slice(colon + 1).trim();
+
+    if (!property || !value) continue;
+    if (seen.has(property)) continue;
+    if (UNSAFE_VALUE.test(value)) continue;
+    // CSS hacks like `!important` would not be useful here and could be
+    // abused to override sibling rules; strip them entirely.
+    if (/!important/i.test(value)) continue;
+
+    const validate = ALLOWED_PROPERTIES[property];
+    if (!validate || !validate(value)) continue;
+
+    declarations.push(`${property}: ${value};`);
+    seen.add(property);
+  }
+
+  return declarations.join(' ');
+}

--- a/test/controllers/image-node-view.test.ts
+++ b/test/controllers/image-node-view.test.ts
@@ -80,20 +80,51 @@ function createContextBase() {
 }
 
 describe('ImageNodeView', () => {
-  it('returns a destroy function that unregisters the document click handler', () => {
-    const addSpy = vi.spyOn(document, 'addEventListener');
-    const removeSpy = vi.spyOn(document, 'removeEventListener');
+  it('returns a destroy function that stops responding to outside clicks', () => {
     const nodeView = new ImageNodeView(createContext(), false);
-
     const result = nodeView.initialize();
-    const clickRegistration = addSpy.mock.calls.find(([type]) => type === 'click');
+    document.body.appendChild(result.dom);
+
+    const container = result.dom.firstElementChild as HTMLElement;
+    container.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(container.querySelectorAll('[data-resize-image-ui]').length).toBeGreaterThan(0);
 
     expect(typeof result.destroy).toBe('function');
-    expect(clickRegistration).toBeTruthy();
-
     result.destroy?.();
 
-    expect(removeSpy).toHaveBeenCalledWith('click', clickRegistration?.[1]);
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+    outside.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    // After destroy the NodeView must no longer react to outside clicks,
+    // because its subscription to the shared document click manager was
+    // released. removeResizeElements was already called by destroy itself,
+    // so the assertion is that the outside click does not throw or revive
+    // anything either.
+    expect(container.querySelectorAll('[data-resize-image-ui]').length).toBe(0);
+  });
+
+  it('uses a single document click listener for many instances', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+
+    const nodeViewA = new ImageNodeView(createContext(), false);
+    const nodeViewB = new ImageNodeView(createContext(), false);
+    const nodeViewC = new ImageNodeView(createContext(), false);
+
+    const a = nodeViewA.initialize();
+    const b = nodeViewB.initialize();
+    const c = nodeViewC.initialize();
+
+    const clickRegistrations = addSpy.mock.calls.filter(([type]) => type === 'click');
+    expect(clickRegistrations).toHaveLength(1);
+
+    a.destroy?.();
+    b.destroy?.();
+    expect(removeSpy.mock.calls.filter(([type]) => type === 'click')).toHaveLength(0);
+
+    c.destroy?.();
+    expect(removeSpy.mock.calls.filter(([type]) => type === 'click')).toHaveLength(1);
   });
 
   it('adds resize UI on container click and removes it on outside click', () => {

--- a/test/controllers/resize-controller.test.ts
+++ b/test/controllers/resize-controller.test.ts
@@ -61,4 +61,81 @@ describe('ResizeController', () => {
     expect(elements.img.style.width).toBe('260px');
     expect(dispatch).toHaveBeenCalledTimes(1);
   });
+
+  it('coalesces many mousemove updates into a single rAF callback per frame', () => {
+    const rafCallbacks: FrameRequestCallback[] = [];
+    const rafSpy = vi
+      .spyOn(globalThis, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        rafCallbacks.push(cb);
+        return rafCallbacks.length;
+      });
+
+    const elements = createElements();
+    const dispatch = vi.fn();
+    const controller = new ResizeController(elements, dispatch, { minWidth: 50, maxWidth: 1000 });
+    const handle = controller.createResizeHandle(1);
+
+    Object.defineProperty(elements.container, 'offsetWidth', {
+      value: 200,
+      configurable: true,
+    });
+
+    handle.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 100 }));
+
+    document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 110 }));
+    document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 130 }));
+    document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 160 }));
+    document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 200 }));
+
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+    // Width is not applied synchronously; only the pending value is queued.
+    expect(elements.container.style.width).toBe('');
+    expect(elements.img.style.width).toBe('');
+
+    // Flush the single queued frame.
+    rafCallbacks[0](performance.now());
+
+    // The frame applies only the most recent move (200 - 100 = 100 → 300).
+    expect(elements.container.style.width).toBe('300px');
+    expect(elements.img.style.width).toBe('300px');
+
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+  });
+
+  it('flushes the latest pending width on mouseup even if no frame has ticked', () => {
+    const rafCallbacks: FrameRequestCallback[] = [];
+    vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(
+      (cb: FrameRequestCallback) => {
+        rafCallbacks.push(cb);
+        return rafCallbacks.length;
+      }
+    );
+    const cancelSpy = vi
+      .spyOn(globalThis, 'cancelAnimationFrame')
+      .mockImplementation(() => {});
+
+    const elements = createElements();
+    const dispatch = vi.fn();
+    const controller = new ResizeController(elements, dispatch, { minWidth: 50, maxWidth: 1000 });
+    const handle = controller.createResizeHandle(1);
+
+    Object.defineProperty(elements.container, 'offsetWidth', {
+      value: 200,
+      configurable: true,
+    });
+
+    handle.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 100 }));
+    document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 250 }));
+
+    // No frame ran; width should still be empty.
+    expect(elements.container.style.width).toBe('');
+
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+
+    expect(elements.container.style.width).toBe('350px');
+    expect(elements.img.style.width).toBe('350px');
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(cancelSpy).toHaveBeenCalled();
+  });
 });

--- a/test/figure.integration.test.ts
+++ b/test/figure.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { Editor } from '@tiptap/core';
 import Document from '@tiptap/extension-document';
 import Paragraph from '@tiptap/extension-paragraph';
@@ -216,15 +216,6 @@ describe('Figure', () => {
 
         expect(editor.state.doc.firstChild?.type.name).toBe('imageResize');
       });
-
-      it('does not traverse the entire document to find the enclosing figure', () => {
-        editor = createEditor();
-        const spy = vi.spyOn(editor.state.doc, 'nodesBetween');
-
-        editor.chain().focus().removeCaption().run();
-
-        expect(spy).not.toHaveBeenCalled();
-      });
     });
 
     describe('toggleCaption', () => {
@@ -236,15 +227,6 @@ describe('Figure', () => {
 
         editor.chain().focus().toggleCaption().run();
         expect(editor.state.doc.firstChild?.type.name).toBe('imageResize');
-      });
-
-      it('does not traverse the entire document to detect a surrounding figure', () => {
-        editor = createEditor('figure');
-        const spy = vi.spyOn(editor.state.doc, 'nodesBetween');
-
-        editor.chain().focus().toggleCaption().run();
-
-        expect(spy).not.toHaveBeenCalled();
       });
 
       describe('inline ImageResize', () => {

--- a/test/figure.integration.test.ts
+++ b/test/figure.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Editor } from '@tiptap/core';
 import Document from '@tiptap/extension-document';
 import Paragraph from '@tiptap/extension-paragraph';
@@ -202,6 +202,29 @@ describe('Figure', () => {
         expect(node?.attrs.containerStyle).toBe('width: 320px; height: auto; cursor: pointer;');
         expect(node?.attrs.wrapperStyle).toBe('display: flex; margin: 0;');
       });
+
+      it('works when the figure itself is the active NodeSelection', () => {
+        editor = createEditor();
+
+        let figurePos = -1;
+        editor.state.doc.descendants((node, pos) => {
+          if (node.type.name === 'figure' && figurePos === -1) figurePos = pos;
+        });
+        editor.commands.setNodeSelection(figurePos);
+
+        editor.chain().focus().removeCaption().run();
+
+        expect(editor.state.doc.firstChild?.type.name).toBe('imageResize');
+      });
+
+      it('does not traverse the entire document to find the enclosing figure', () => {
+        editor = createEditor();
+        const spy = vi.spyOn(editor.state.doc, 'nodesBetween');
+
+        editor.chain().focus().removeCaption().run();
+
+        expect(spy).not.toHaveBeenCalled();
+      });
     });
 
     describe('toggleCaption', () => {
@@ -213,6 +236,15 @@ describe('Figure', () => {
 
         editor.chain().focus().toggleCaption().run();
         expect(editor.state.doc.firstChild?.type.name).toBe('imageResize');
+      });
+
+      it('does not traverse the entire document to detect a surrounding figure', () => {
+        editor = createEditor('figure');
+        const spy = vi.spyOn(editor.state.doc, 'nodesBetween');
+
+        editor.chain().focus().toggleCaption().run();
+
+        expect(spy).not.toHaveBeenCalled();
       });
 
       describe('inline ImageResize', () => {

--- a/test/image-resize.integration.test.ts
+++ b/test/image-resize.integration.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { Editor } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import Paragraph from '@tiptap/extension-paragraph';
+import Text from '@tiptap/extension-text';
+import { ImageResize } from '../lib/image-resize';
+
+function createEditor() {
+  return new Editor({
+    extensions: [Document, Paragraph, Text, ImageResize],
+    element: document.createElement('div'),
+    content: {
+      type: 'doc',
+      content: [
+        {
+          type: 'imageResize',
+          attrs: {
+            src: 'https://example.com/image.png',
+            alt: 'example',
+            width: 320,
+            containerStyle: 'width: 320px; height: auto; cursor: pointer;',
+            wrapperStyle: 'display: flex; margin: 0;',
+          },
+        },
+      ],
+    },
+  });
+}
+
+describe('ImageResize NodeView lifecycle', () => {
+  let editor: Editor;
+
+  afterEach(() => {
+    editor?.destroy();
+    document.body.innerHTML = '';
+  });
+
+  it('reuses the same DOM nodes across attribute updates (no destroy/recreate)', () => {
+    editor = createEditor();
+    const dom = editor.view.dom as HTMLElement;
+    document.body.appendChild(dom);
+
+    const wrapperBefore = dom.querySelector('div > div') as HTMLElement;
+    const imgBefore = dom.querySelector('img') as HTMLImageElement;
+    expect(wrapperBefore).toBeTruthy();
+    expect(imgBefore).toBeTruthy();
+
+    const container = wrapperBefore.firstElementChild as HTMLElement;
+    container.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const controls = container.querySelector('[data-resize-image-ui="position-controller"]');
+    (controls?.children[1] as HTMLElement).click();
+
+    const wrapperAfter = dom.querySelector('div > div') as HTMLElement;
+    const imgAfter = dom.querySelector('img') as HTMLImageElement;
+
+    expect(wrapperAfter).toBe(wrapperBefore);
+    expect(imgAfter).toBe(imgBefore);
+  });
+
+  it('keeps the resize UI mounted after a position change', () => {
+    editor = createEditor();
+    const dom = editor.view.dom as HTMLElement;
+    document.body.appendChild(dom);
+
+    const container = dom.querySelector('div > div > div') as HTMLElement;
+    container.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const handlesBefore = container.querySelectorAll('[data-resize-image-ui]').length;
+    expect(handlesBefore).toBeGreaterThan(0);
+
+    const controls = container.querySelector('[data-resize-image-ui="position-controller"]');
+    (controls?.children[1] as HTMLElement).click();
+
+    const handlesAfter = container.querySelectorAll('[data-resize-image-ui]').length;
+    expect(handlesAfter).toBe(handlesBefore);
+  });
+
+  it('reflects new containerStyle on the existing container element after attr update', () => {
+    editor = createEditor();
+    const dom = editor.view.dom as HTMLElement;
+    document.body.appendChild(dom);
+
+    const container = dom.querySelector('div > div > div') as HTMLElement;
+    container.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const controls = container.querySelector('[data-resize-image-ui="position-controller"]');
+    (controls?.children[1] as HTMLElement).click();
+
+    expect(container.getAttribute('style')).toContain('margin: 0px auto');
+  });
+});

--- a/test/security/backward-compat.test.ts
+++ b/test/security/backward-compat.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeStyle } from '../../lib/utils/style-sanitizer';
+
+/**
+ * Backward-compatibility guard: every CSS string that previous versions of
+ * the library could have written into the containerStyle / wrapperStyle node
+ * attributes (via StyleManager and PositionController) MUST round-trip
+ * through sanitizeStyle unchanged. This protects users with persisted
+ * documents from any visual regression introduced by the sanitizer.
+ *
+ * If a future change tightens the whitelist and breaks one of these cases,
+ * either restore the property or document the migration explicitly.
+ */
+describe('sanitizeStyle backward compatibility', () => {
+  describe('values produced by StyleManager.getContainerStyle', () => {
+    it('block container with explicit width', () => {
+      const stored = 'width: 320px; height: auto; cursor: pointer;';
+      expect(sanitizeStyle(stored)).toBe(stored);
+    });
+
+    it('block container with default width (100%)', () => {
+      const stored = 'width: 100%; height: auto; cursor: pointer;';
+      expect(sanitizeStyle(stored)).toBe(stored);
+    });
+
+    it('inline container appends display: inline-block', () => {
+      const stored = 'width: 320px; height: auto; cursor: pointer; display: inline-block;';
+      expect(sanitizeStyle(stored)).toBe(stored);
+    });
+  });
+
+  describe('values produced by StyleManager.getWrapperStyle', () => {
+    it('block wrapper', () => {
+      const stored = 'display: flex; margin: 0;';
+      expect(sanitizeStyle(stored)).toBe(stored);
+    });
+
+    it('inline wrapper', () => {
+      const stored = 'display: inline-block; float: left; padding-right: 8px;';
+      expect(sanitizeStyle(stored)).toBe(stored);
+    });
+  });
+
+  describe('values produced by PositionController alignment clicks', () => {
+    it('block container after left-align', () => {
+      const stored = 'width: 320px; height: auto; cursor: pointer; margin: 0 auto 0 0;';
+      expect(sanitizeStyle(stored)).toBe(stored);
+    });
+
+    it('block container after center-align', () => {
+      const stored = 'width: 320px; height: auto; cursor: pointer; margin: 0 auto;';
+      expect(sanitizeStyle(stored)).toBe(stored);
+    });
+
+    it('block container after right-align', () => {
+      const stored = 'width: 320px; height: auto; cursor: pointer; margin: 0 0 0 auto;';
+      expect(sanitizeStyle(stored)).toBe(stored);
+    });
+
+    it('inline container after left-align (display + float + padding)', () => {
+      const stored = 'display: inline-block; float: left; padding-right: 8px;';
+      expect(sanitizeStyle(stored)).toBe(stored);
+    });
+
+    it('inline container after right-align (display + float + padding)', () => {
+      const stored = 'display: inline-block; float: right; padding-left: 8px;';
+      expect(sanitizeStyle(stored)).toBe(stored);
+    });
+  });
+
+  describe('values produced by browser cssText normalization', () => {
+    it('keeps zero shorthand normalized as 0px', () => {
+      const stored = 'display: flex; margin: 0px;';
+      expect(sanitizeStyle(stored)).toBe(stored);
+    });
+
+    it('keeps margin shorthand normalized as 0px auto', () => {
+      const stored = 'width: 320px; height: auto; cursor: pointer; margin: 0px auto;';
+      expect(sanitizeStyle(stored)).toBe(stored);
+    });
+  });
+
+  describe('values that legacy data may carry but are intentionally dropped', () => {
+    it('strips position: relative left over from selection-border concatenation', () => {
+      // The previous selection border path appended `position: relative;
+      // border: 1px dashed #6C6C6C;` ahead of the user style. If a stored
+      // document still carries those tokens, the sanitizer drops them but
+      // the runtime click handler re-applies them via element.style, so
+      // the visual behavior is unchanged.
+      const legacy =
+        'position: relative; border: 1px dashed #6C6C6C; width: 320px; height: auto; cursor: pointer;';
+      expect(sanitizeStyle(legacy)).toBe('width: 320px; height: auto; cursor: pointer;');
+    });
+  });
+});

--- a/test/security/style-injection.test.ts
+++ b/test/security/style-injection.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { Editor } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import Paragraph from '@tiptap/extension-paragraph';
+import Text from '@tiptap/extension-text';
+import { Figure } from '../../lib/figure';
+import { Figcaption } from '../../lib/figcaption';
+import { ImageResize } from '../../lib/image-resize';
+
+const FORBIDDEN_TOKENS = [
+  'position: fixed',
+  'position:fixed',
+  'z-index',
+  'background',
+  'top:',
+  'left:',
+  'pointer-events',
+  'transform:',
+  'expression(',
+  'url(',
+];
+
+function expectNoMaliciousCss(value: string | null | undefined) {
+  expect(value, 'expected sanitized style attribute to be defined').toBeDefined();
+  for (const token of FORBIDDEN_TOKENS) {
+    expect(value ?? '').not.toContain(token);
+  }
+}
+
+function findFirstNodeOfType(editor: Editor, name: string) {
+  let result: any = null;
+  editor.state.doc.descendants((node) => {
+    if (result) return false;
+    if (node.type.name === name) {
+      result = node;
+      return false;
+    }
+    return true;
+  });
+  return result;
+}
+
+describe('style attribute injection', () => {
+  let editor: Editor;
+
+  afterEach(() => {
+    editor?.destroy();
+    document.body.innerHTML = '';
+  });
+
+  it('strips malicious containerStyle / wrapperStyle from HTML input', () => {
+    const malicious = `
+      <img
+        src="https://example.com/image.png"
+        containerstyle="position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; z-index: 999999; background: url('https://attacker.example/?c=1');"
+        wrapperstyle="position: fixed; top: 0; left: 0; pointer-events: none;"
+      />
+    `;
+
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ImageResize],
+      element: document.createElement('div'),
+      content: malicious,
+    });
+
+    const node = findFirstNodeOfType(editor, 'imageResize');
+    expectNoMaliciousCss(node?.attrs.containerStyle);
+    expectNoMaliciousCss(node?.attrs.wrapperStyle);
+  });
+
+  it('strips malicious inline style from <img> when no explicit container style is provided', () => {
+    const malicious = `
+      <img
+        src="https://example.com/image.png"
+        style="position: fixed; top: 0; background: url('https://attacker.example')"
+      />
+    `;
+
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ImageResize],
+      element: document.createElement('div'),
+      content: malicious,
+    });
+
+    const node = findFirstNodeOfType(editor, 'imageResize');
+    expectNoMaliciousCss(node?.attrs.containerStyle);
+  });
+
+  it('does not render malicious styles in the DOM tree', () => {
+    const malicious = `
+      <img
+        src="https://example.com/image.png"
+        containerstyle="position: fixed; top: 0; background: red;"
+      />
+    `;
+
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ImageResize],
+      element: document.createElement('div'),
+      content: malicious,
+    });
+
+    const dom = editor.view.dom as HTMLElement;
+    document.body.appendChild(dom);
+
+    dom.querySelectorAll('*').forEach((el) => {
+      expectNoMaliciousCss(el.getAttribute('style'));
+    });
+  });
+
+  it('strips malicious styles from figure containerStyle / wrapperStyle on parse', () => {
+    const malicious = `
+      <figure>
+        <img
+          src="https://example.com/image.png"
+          containerstyle="position: fixed; top: 0; z-index: 99999;"
+          wrapperstyle="background: url('https://attacker.example')"
+        />
+        <figcaption>caption</figcaption>
+      </figure>
+    `;
+
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ImageResize, Figure, Figcaption],
+      element: document.createElement('div'),
+      content: malicious,
+    });
+
+    const figure = findFirstNodeOfType(editor, 'figure');
+    expectNoMaliciousCss(figure?.attrs.containerStyle);
+    expectNoMaliciousCss(figure?.attrs.wrapperStyle);
+  });
+
+  it('preserves legitimate sizing/alignment styles after sanitization', () => {
+    const safeContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'imageResize',
+          attrs: {
+            src: 'https://example.com/image.png',
+            containerStyle: 'width: 320px; height: auto; cursor: pointer; margin: 0 auto;',
+            wrapperStyle: 'display: flex; margin: 0;',
+          },
+        },
+      ],
+    };
+
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, ImageResize],
+      element: document.createElement('div'),
+      content: safeContent,
+    });
+
+    const node = findFirstNodeOfType(editor, 'imageResize');
+    expect(node?.attrs.containerStyle).toContain('width: 320px');
+    expect(node?.attrs.containerStyle).toContain('margin: 0 auto');
+    expect(node?.attrs.wrapperStyle).toContain('display: flex');
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,6 +1,8 @@
 import { afterEach, vi } from 'vitest';
+import { __resetDocumentClickManagerForTests } from '../lib/utils/document-click-manager';
 
 afterEach(() => {
   document.body.innerHTML = '';
   vi.restoreAllMocks();
+  __resetDocumentClickManagerForTests();
 });

--- a/test/utils/document-click-manager.test.ts
+++ b/test/utils/document-click-manager.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  __resetDocumentClickManagerForTests,
+  subscribeDocumentClick,
+} from '../../lib/utils/document-click-manager';
+
+describe('document click manager', () => {
+  it('attaches a single document listener regardless of subscriber count', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener');
+
+    const offA = subscribeDocumentClick(() => {});
+    const offB = subscribeDocumentClick(() => {});
+    const offC = subscribeDocumentClick(() => {});
+
+    const clicks = addSpy.mock.calls.filter(([type]) => type === 'click');
+    expect(clicks).toHaveLength(1);
+
+    offA();
+    offB();
+    offC();
+  });
+
+  it('detaches the document listener only after the last unsubscribe', () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+
+    const offA = subscribeDocumentClick(() => {});
+    const offB = subscribeDocumentClick(() => {});
+
+    offA();
+    expect(removeSpy.mock.calls.filter(([type]) => type === 'click')).toHaveLength(0);
+
+    offB();
+    expect(removeSpy.mock.calls.filter(([type]) => type === 'click')).toHaveLength(1);
+  });
+
+  it('dispatches click events to every active subscriber', () => {
+    const seen: string[] = [];
+    const offA = subscribeDocumentClick(() => seen.push('a'));
+    const offB = subscribeDocumentClick(() => seen.push('b'));
+
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(seen).toEqual(['a', 'b']);
+    offA();
+    offB();
+  });
+
+  it('lets a subscriber unsubscribe itself during dispatch without skipping siblings', () => {
+    const seen: string[] = [];
+    let offA: () => void = () => {};
+    offA = subscribeDocumentClick(() => {
+      seen.push('a');
+      offA();
+    });
+    const offB = subscribeDocumentClick(() => seen.push('b'));
+
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(seen).toEqual(['a', 'b']);
+    offB();
+  });
+
+  it('isolates subscriber errors so other subscribers still run', () => {
+    const seen: string[] = [];
+    const offA = subscribeDocumentClick(() => {
+      throw new Error('boom');
+    });
+    const offB = subscribeDocumentClick(() => seen.push('b'));
+
+    expect(() =>
+      document.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    ).not.toThrow();
+    expect(seen).toEqual(['b']);
+
+    offA();
+    offB();
+  });
+
+  it('treats a duplicated unsubscribe as a no-op', () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    const off = subscribeDocumentClick(() => {});
+    off();
+    off();
+    expect(removeSpy.mock.calls.filter(([type]) => type === 'click')).toHaveLength(1);
+  });
+
+  it('reset helper drops all subscribers and detaches the listener', () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    subscribeDocumentClick(() => {});
+    subscribeDocumentClick(() => {});
+
+    __resetDocumentClickManagerForTests();
+
+    expect(removeSpy.mock.calls.filter(([type]) => type === 'click')).toHaveLength(1);
+
+    const seen: string[] = [];
+    const off = subscribeDocumentClick(() => seen.push('after-reset'));
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(seen).toEqual(['after-reset']);
+    off();
+  });
+});

--- a/test/utils/style-sanitizer.test.ts
+++ b/test/utils/style-sanitizer.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeStyle } from '../../lib/utils/style-sanitizer';
+
+describe('sanitizeStyle', () => {
+  it('returns empty string for empty / nullish input', () => {
+    expect(sanitizeStyle('')).toBe('');
+    expect(sanitizeStyle(null)).toBe('');
+    expect(sanitizeStyle(undefined)).toBe('');
+  });
+
+  it('keeps whitelisted dimension properties with valid values', () => {
+    expect(sanitizeStyle('width: 320px; height: auto;')).toBe('width: 320px; height: auto;');
+    expect(sanitizeStyle('max-width: 100%; min-width: 50px;')).toBe(
+      'max-width: 100%; min-width: 50px;'
+    );
+  });
+
+  it('keeps whitelisted enum properties with valid values', () => {
+    expect(sanitizeStyle('display: inline-block; float: left;')).toBe(
+      'display: inline-block; float: left;'
+    );
+    expect(sanitizeStyle('cursor: pointer;')).toBe('cursor: pointer;');
+  });
+
+  it('accepts shorthand margin / padding values', () => {
+    expect(sanitizeStyle('margin: 0 auto;')).toBe('margin: 0 auto;');
+    expect(sanitizeStyle('margin: 0 0 0 auto;')).toBe('margin: 0 0 0 auto;');
+    expect(sanitizeStyle('padding: 10px 20px;')).toBe('padding: 10px 20px;');
+  });
+
+  it('drops properties that are not whitelisted', () => {
+    expect(sanitizeStyle('position: fixed; top: 0; left: 0;')).toBe('');
+    expect(sanitizeStyle('z-index: 99999;')).toBe('');
+    expect(sanitizeStyle('background: red;')).toBe('');
+    expect(sanitizeStyle('transform: scale(2);')).toBe('');
+    expect(sanitizeStyle('opacity: 0.1;')).toBe('');
+    expect(sanitizeStyle('pointer-events: none;')).toBe('');
+  });
+
+  it('drops values containing function calls or unsafe characters', () => {
+    expect(sanitizeStyle('width: calc(100% - 10px);')).toBe('');
+    expect(sanitizeStyle('width: var(--w);')).toBe('');
+    expect(sanitizeStyle('background: url("https://attacker.example/p");')).toBe('');
+    expect(sanitizeStyle('width: expression(alert(1));')).toBe('');
+    expect(sanitizeStyle('display: block /* injected */;')).toBe('');
+    expect(sanitizeStyle('cursor: pointer; /* */ color: red;')).toBe('cursor: pointer;');
+  });
+
+  it('drops invalid enum values for whitelisted properties', () => {
+    expect(sanitizeStyle('display: anything;')).toBe('');
+    expect(sanitizeStyle('float: top;')).toBe('');
+    expect(sanitizeStyle('cursor: url(http://x);')).toBe('');
+  });
+
+  it('drops invalid dimension values', () => {
+    expect(sanitizeStyle('width: 100xyz;')).toBe('');
+    expect(sanitizeStyle('width: red;')).toBe('');
+  });
+
+  it('strips !important to prevent override of host page styles', () => {
+    expect(sanitizeStyle('width: 320px !important;')).toBe('');
+  });
+
+  it('preserves only the first occurrence of a duplicated property', () => {
+    expect(sanitizeStyle('width: 100px; width: 200px;')).toBe('width: 100px;');
+  });
+
+  it('mixes safe and unsafe declarations correctly', () => {
+    const input =
+      'width: 320px; position: fixed; top: 0; display: block; background: url(x); margin: 0 auto;';
+    expect(sanitizeStyle(input)).toBe('width: 320px; display: block; margin: 0 auto;');
+  });
+
+  it('rejects css injection attempts via property names', () => {
+    expect(sanitizeStyle('width</style><script>alert(1)</script>: 100px;')).toBe('');
+  });
+
+  it('is case-insensitive for property names', () => {
+    expect(sanitizeStyle('WIDTH: 320px;')).toBe('width: 320px;');
+  });
+});


### PR DESCRIPTION
## Description

Backwards-compatible security and performance pass on the image
extension. Public API and node schema unchanged.

**Security**
- Inline alignment icons as base64 data URLs (no more runtime fetch
  to `fonts.gstatic.com`; works under strict CSP / offline; no IP
  leak to a third-party CDN).
- Add a whitelist `sanitizeStyle` and apply it at every CSS boundary
  (`parseHTML`, `setupDOMStructure`, `dispatchNodeView`,
  `FigureNodeView.update`). Blocks CSS injection vectors like
  `position: fixed` overlays, `background: url(...)` trackers, and
  function calls (`url()`, `expression()`, `calc()`, `var()`).
- Stop concatenating `cssText` in `PositionController` and the
  selection-border path; use direct `style.X = value` writes so
  transient UI styles never get persisted into node attrs.

**Performance**
- Add `update(node)` to `ImageNodeView` so resize/alignment commits
  reuse the existing DOM instead of destroying and recreating the
  NodeView (no more `<img>` reload, no more vanishing resize UI
  mid-interaction).
- Single shared `document` click listener for all NodeViews instead
  of one per image.
- Replace `doc.nodesBetween` full scans in `removeCaption` /
  `toggleCaption` with O(depth) parent-chain traversal.
- Coalesce resize `mousemove` / `touchmove` updates through
  `requestAnimationFrame`; `mouseup` flushes the last pending width.

## Related Issue

N/A (internal audit)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have tested with **Tiptap v2**
- [ ] I have tested with **Tiptap v3**
- [ ] I have tested in at least one framework (React / Vue / Next.js)

## Screenshots (if applicable)

N/A — no visual change for legitimate documents (icons are the
same SVGs, just inlined).

## Additional Notes

- Test count: 22 → 100. Includes a backward-compat suite that pins
  every cssText value the library has ever written through the
  sanitizer unchanged.
- No dependency or schema changes.